### PR TITLE
fix

### DIFF
--- a/app/assets/stylesheets/sessions.scss
+++ b/app/assets/stylesheets/sessions.scss
@@ -3,7 +3,27 @@
 // You can use Sass (SCSS) here: http://sass-lang.com/
 
 .container {
-	background-color: skyblue;
+	background-color: whitesmoke;
 	width: 500px;
 	margin: 50px auto;
+}
+
+.form-item {
+	margin-bottom: 50px;
+}
+
+.form-control {
+	display: block;
+	width: 90%;
+	height: calc(2.25rem + 2px);
+	border: 0;
+	padding: 10px;
+	font-size: 1.4rem;
+	font-family: Arial, sans-serif;
+	color: #34495e;
+	border: solid 1px #ccc;
+	margin: 0 0 20px;
+	line-height: 1.5;
+	border-radius: 0.25rem;
+
 }

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,4 +1,7 @@
 class Admin::UsersController < ApplicationController
+  # ユーザ新規登録機能をログインしていなくても
+  skip_before_action :login_required, only: %i[new create]
+
   def index
     @users = User.all
   end

--- a/app/views/admin/users/new.html.erb
+++ b/app/views/admin/users/new.html.erb
@@ -6,7 +6,7 @@
 <h1>ユーザ登録</h1>
 
 <div class="nav justify-content-end">
-    <%=link_to 'back page', admin_users_path, class: 'nav-link'%>
+  <%=link_to 'back page', admin_users_path, class: 'nav-link'%>
 </div>
 
 <%= render partial: 'users_form', locals: { user: @user }%>

--- a/app/views/partial/_navbar.html.erb
+++ b/app/views/partial/_navbar.html.erb
@@ -43,7 +43,7 @@
 	<div class="item">
 			<%= link_to login_path, data: {"turbolinks" => false} do %>
 				<div class="text">
-					<i class="fas fa-sign-out-alt">サインアップ</i>
+					<i class="fas fa-sign-out-alt">ログイン</i>
 				</div>
 			<% end %>
 		</div>
@@ -51,7 +51,7 @@
 		<div class="item">
 			<%= link_to new_admin_user_path, data: {"turbolinks" => false} do %>
 				<div class="text">
-					<i class="fas fa-sign-out-alt">サインイン</i>
+					<i class="fas fa-sign-out-alt">新規登録</i>
 				</div>
 			<% end %>
 		</div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -3,13 +3,13 @@
 <% end %>
 
 <div class="container">
-  <h1>ログイン</h1>
+  <h1 class="form-item">ログイン</h1>
   <%=form_with scope: :session, local: true do |f|%>
-    <div class="form-group">
+    <div class="form-item">
       <%=f.label :email, 'メールアドレス'%>
       <%=f.text_field :email, class: 'form-control', id: 'session_email'%>
     </div>
-    <div class="form-group">
+    <div class="form-item">
       <%=f.label :password, 'パスワード'%>
       <%=f.password_field :password, class: 'form-control', id: 'session_password'%>
     </div>


### PR DESCRIPTION
ユーザ新規登録画面への遷移ができなかったため修正しました。
ログインフォームのスタイル作成

app/controllers/admin/users_controller.rbに
  skip_before_action :login_required, only: %i[new create]
を追加してログインしていなくてもユーザ新規登録機能は使えるようにしました。
